### PR TITLE
Better submit buttons

### DIFF
--- a/components/form.tsx
+++ b/components/form.tsx
@@ -9,7 +9,7 @@ import {
 } from "react-hook-form";
 
 import clsx from "clsx";
-import { Check, LoaderCircle } from "lucide-react";
+import { Check, LoaderCircle, Save } from "lucide-react";
 import { cn } from "../lib/utils.js";
 import { Button, type ButtonProps } from "./shadcn/button.js";
 import {
@@ -30,6 +30,7 @@ import {
 } from "./shadcn/select.js";
 import { Switch } from "./shadcn/switch.js";
 import { Textarea as ShadTextarea } from "./shadcn/textarea.js";
+import { createElement } from "react";
 
 interface Props<T extends FieldValues>
   extends Omit<React.FormHTMLAttributes<HTMLFormElement>, "onSubmit"> {
@@ -246,30 +247,49 @@ interface SubmitProps extends ButtonProps {
   label: React.ReactNode;
   skipDirtyCheck?: boolean;
   isSubmitting?: boolean;
+  submittingLabel?: string;
+  successLabel?: string;
 }
 
 function Submit({
   skipDirtyCheck = false,
-  label,
+  label = "Save",
+  submittingLabel = "Saving",
+  successLabel = "Saved",
   isSubmitting: isSubmittingOverride = false,
   ...rest
 }: SubmitProps) {
   const {
-    formState: { isValid, isDirty, isSubmitting },
+    formState: { isValid, isDirty, isSubmitting, isSubmitSuccessful },
   } = useFormContext();
+
+  const isSubmittingWithOverride = isSubmittingOverride || isSubmitting;
 
   const disabled = skipDirtyCheck
     ? !isValid || isSubmitting
     : !isDirty || !isValid || isSubmitting;
 
+  const computedLabel = isSubmittingWithOverride
+    ? submittingLabel
+    : isSubmitSuccessful
+      ? successLabel
+      : label;
+
+  const icon = isSubmittingWithOverride
+    ? LoaderCircle
+    : isDirty
+      ? Save
+      : isSubmitSuccessful
+        ? Check
+        : Save;
+  const iconProps = isSubmittingWithOverride
+    ? { className: "animate-spin" }
+    : {};
+
   return (
     <Button type="submit" disabled={disabled} {...rest}>
-      {isSubmitting || isSubmittingOverride ? (
-        <LoaderCircle className="animate-spin" />
-      ) : (
-        <Check />
-      )}
-      {label}
+      {createElement(icon, iconProps)}
+      {computedLabel}
     </Button>
   );
 }

--- a/components/form.tsx
+++ b/components/form.tsx
@@ -275,8 +275,8 @@ function Submit({
   const isSubmittingWithOverride = isSubmittingOverride || isSubmitting;
 
   const disabled = skipDirtyCheck
-    ? !isValid || isSubmitting
-    : !isDirty || !isValid || isSubmitting;
+    ? !isValid || isSubmittingWithOverride
+    : !isDirty || !isValid || isSubmittingWithOverride;
 
   let labelMapping =
     typeof label === "string" ? SubmitLabelMapping[label.toLowerCase()] : label;

--- a/components/form.tsx
+++ b/components/form.tsx
@@ -287,13 +287,16 @@ function Submit({
       ? labelMapping.saved
       : labelMapping.save;
 
-  const icon = isSubmittingWithOverride
-    ? LoaderCircle
-    : isDirty
-      ? Save
-      : isSubmitSuccessful
-        ? Check
-        : Save;
+  let icon;
+  if (isSubmittingWithOverride) {
+    icon = LoaderCircle;
+  } else if (isDirty) {
+    icon = Save;
+  } else if (isSubmitSuccessful) {
+    icon = Check;
+  } else {
+    icon = Save;
+  }
   const iconProps = isSubmittingWithOverride
     ? { className: "animate-spin" }
     : {};

--- a/components/form.tsx
+++ b/components/form.tsx
@@ -243,8 +243,19 @@ function Checkbox<T extends FieldValues>({ name, label }: BaseInputProps<T>) {
 }
 Form.Checkbox = Checkbox;
 
+interface SubmitLabelMapping {
+  save: string;
+  saving: string;
+  saved: string;
+}
+
+const SubmitLabelMapping: Record<string, SubmitLabelMapping> = {
+  save: { save: "Save", saving: "Saving", saved: "Saved" },
+  unlock: { save: "Unlock", saving: "Unlocking", saved: "Unlocked" },
+};
+
 interface SubmitProps extends ButtonProps {
-  label: React.ReactNode;
+  label: string | SubmitLabelMapping;
   skipDirtyCheck?: boolean;
   isSubmitting?: boolean;
   submittingLabel?: string;
@@ -253,9 +264,7 @@ interface SubmitProps extends ButtonProps {
 
 function Submit({
   skipDirtyCheck = false,
-  label = "Save",
-  submittingLabel = "Saving",
-  successLabel = "Saved",
+  label = SubmitLabelMapping.save,
   isSubmitting: isSubmittingOverride = false,
   ...rest
 }: SubmitProps) {
@@ -269,11 +278,14 @@ function Submit({
     ? !isValid || isSubmitting
     : !isDirty || !isValid || isSubmitting;
 
+  let labelMapping =
+    typeof label === "string" ? SubmitLabelMapping[label.toLowerCase()] : label;
+
   const computedLabel = isSubmittingWithOverride
-    ? submittingLabel
+    ? labelMapping.saving
     : isSubmitSuccessful
-      ? successLabel
-      : label;
+      ? labelMapping.saved
+      : labelMapping.save;
 
   const icon = isSubmittingWithOverride
     ? LoaderCircle

--- a/stories/forms/Submit.stories.tsx
+++ b/stories/forms/Submit.stories.tsx
@@ -1,0 +1,106 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import React from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { Form } from "../../components/form.js";
+
+const meta = {
+  title: "Components/Form/Submit",
+  component: Form.Submit,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  decorators: [
+    (Story) => (
+      <div className="w-md">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof Form.Submit>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const WithRequiredInput: Story = {
+  decorators: [
+    (Story) => {
+      const schema = z.object({
+        required: z.string().min(1),
+      });
+
+      const form = useForm({
+        resolver: zodResolver(schema),
+      });
+
+      const onSubmit = async () => {
+        console.log("submitting");
+        await new Promise((resolve) => setTimeout(resolve, 500));
+        console.log("submitted");
+        form.reset({}, { keepValues: true });
+      };
+
+      return (
+        <Form form={form} onSubmit={onSubmit}>
+          <Form.Text
+            name="required"
+            label="Required field"
+            className="w-full"
+          />
+          <div className="flex gap-2">
+            <Story />
+          </div>
+        </Form>
+      );
+    },
+  ],
+
+  args: {
+    name: "default",
+    label: "Save",
+    className: "w-full",
+  },
+};
+
+export const WithOptionalInput: Story = {
+  decorators: [
+    (Story) => {
+      const schema = z.object({
+        optional: z.string().optional(),
+      });
+
+      const form = useForm({
+        resolver: zodResolver(schema),
+      });
+
+      const onSubmit = async () => {
+        console.log("submitting");
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+        console.log("submitted");
+        form.reset({}, { keepValues: true });
+      };
+
+      return (
+        <Form form={form} onSubmit={onSubmit}>
+          <Form.Text
+            name="optional"
+            label="Optional field"
+            className="w-full"
+          />
+          <div className="flex gap-2">
+            <Story />
+          </div>
+        </Form>
+      );
+    },
+  ],
+
+  args: {
+    name: "default",
+    label: "Default text input",
+    className: "w-full",
+  },
+};

--- a/stories/forms/Submit.stories.tsx
+++ b/stories/forms/Submit.stories.tsx
@@ -100,7 +100,7 @@ export const WithOptionalInput: Story = {
 
   args: {
     name: "default",
-    label: "Default text input",
+    label: "Submit",
     className: "w-full",
   },
 };


### PR DESCRIPTION
Targeting this issue from the main repo: https://github.com/ethui/ethui/issues/1229

overall changes:
- the icon now switches between a spinner (during submission), a check (when a valid submission was made) and a floppy disk (when the form is dirty)
- the button still shows as disabled when the form is either not dirty or invalid
- labels for all 3 states are now required