### PR TITLE
rename isSubmitting override

### DIFF
--- a/components/form.tsx
+++ b/components/form.tsx
@@ -257,7 +257,6 @@ const submitLabelKnownMappings: Record<string, SubmitLabelMapping> = {
 interface SubmitProps extends ButtonProps {
   label: string | SubmitLabelMapping;
   skipDirtyCheck?: boolean;
-  isSubmitting?: boolean;
   submittingLabel?: string;
   successLabel?: string;
 }
@@ -265,18 +264,15 @@ interface SubmitProps extends ButtonProps {
 function Submit({
   skipDirtyCheck = false,
   label = submitLabelKnownMappings.save,
-  isSubmitting: isSubmittingOverride = false,
   ...rest
 }: SubmitProps) {
   const {
     formState: { isValid, isDirty, isSubmitting, isSubmitSuccessful },
   } = useFormContext();
 
-  const isSubmittingWithOverride = isSubmittingOverride || isSubmitting;
-
   const disabled = skipDirtyCheck
-    ? !isValid || isSubmittingWithOverride
-    : !isDirty || !isValid || isSubmittingWithOverride;
+    ? !isValid || isSubmitting
+    : !isDirty || !isValid || isSubmitting;
 
   const labelMapping =
     typeof label === "string"
@@ -287,7 +283,7 @@ function Submit({
   if (!labelMapping) {
     // at this point it can only be a string
     computedLabel = label as string;
-  } else if (isSubmittingWithOverride) {
+  } else if (isSubmitting) {
     computedLabel = labelMapping.saving;
   } else if (isSubmitSuccessful) {
     computedLabel = labelMapping.saved;
@@ -296,7 +292,7 @@ function Submit({
   }
 
   let icon: LucideIcon;
-  if (isSubmittingWithOverride) {
+  if (isSubmitting) {
     icon = LoaderCircle;
   } else if (isDirty) {
     icon = Save;
@@ -305,9 +301,7 @@ function Submit({
   } else {
     icon = Save;
   }
-  const iconProps = isSubmittingWithOverride
-    ? { className: "animate-spin" }
-    : {};
+  const iconProps = isSubmitting ? { className: "animate-spin" } : {};
 
   return (
     <Button type="submit" disabled={disabled} {...rest}>

--- a/components/form.tsx
+++ b/components/form.tsx
@@ -257,6 +257,7 @@ const submitLabelKnownMappings: Record<string, SubmitLabelMapping> = {
 interface SubmitProps extends ButtonProps {
   label: string | SubmitLabelMapping;
   skipDirtyCheck?: boolean;
+  forceLoading?: boolean;
   submittingLabel?: string;
   successLabel?: string;
 }
@@ -264,15 +265,18 @@ interface SubmitProps extends ButtonProps {
 function Submit({
   skipDirtyCheck = false,
   label = submitLabelKnownMappings.save,
+  forceLoading,
   ...rest
 }: SubmitProps) {
   const {
-    formState: { isValid, isDirty, isSubmitting, isSubmitSuccessful },
+    formState: { isValid, isDirty, isSubmitSuccessful, isSubmitting },
   } = useFormContext();
 
+  const isLoading = isSubmitting || forceLoading;
+
   const disabled = skipDirtyCheck
-    ? !isValid || isSubmitting
-    : !isDirty || !isValid || isSubmitting;
+    ? !isValid || isLoading
+    : !isDirty || !isValid || isLoading;
 
   const labelMapping =
     typeof label === "string"
@@ -283,7 +287,7 @@ function Submit({
   if (!labelMapping) {
     // at this point it can only be a string
     computedLabel = label as string;
-  } else if (isSubmitting) {
+  } else if (isLoading) {
     computedLabel = labelMapping.saving;
   } else if (isSubmitSuccessful) {
     computedLabel = labelMapping.saved;
@@ -292,7 +296,7 @@ function Submit({
   }
 
   let icon: LucideIcon;
-  if (isSubmitting) {
+  if (isLoading) {
     icon = LoaderCircle;
   } else if (isDirty) {
     icon = Save;
@@ -301,7 +305,7 @@ function Submit({
   } else {
     icon = Save;
   }
-  const iconProps = isSubmitting ? { className: "animate-spin" } : {};
+  const iconProps = isLoading ? { className: "animate-spin" } : {};
 
   return (
     <Button type="submit" disabled={disabled} {...rest}>


### PR DESCRIPTION
This flag is used to force a specific form to keep a loading behavior while waiting for async data. the new name suits the job better