### PR TITLE
experimente: remove rewriteRelativeImportExtensions requirement

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -19,7 +19,6 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
-    "rewriteRelativeImportExtensions": true,
 
     "types": ["node"],
     "typeRoots": ["@types", "./node_modules/@types", "./node_modules"],


### PR DESCRIPTION
Remove the "rewriteRelativeImportExtensions": true setting from TypeScript config to allow cleaner imports without .js extensions in TypeScript source files